### PR TITLE
Fix packet id for custom text list leaderboard

### DIFF
--- a/src/packet/UpdateLeaderboard.js
+++ b/src/packet/UpdateLeaderboard.js
@@ -31,7 +31,7 @@ UpdateLeaderboard.prototype.build = function() {
             var view = new DataView(buf);
 
             // Set packet data
-            view.setUint8(0, 49, true); // Packet ID
+            view.setUint8(0, this.packetLB, true); // Packet ID
             view.setUint32(1, validElements, true); // Number of elements
             var offset = 5;
 


### PR DESCRIPTION
Currently it is a hardcoded 49 instead of 48 and I strongly suspect it is an error.

Using `this.packetLB` makes it consistent with other case statements.
