### PR TITLE
Prevent bots from "shooting" mother cells

### DIFF
--- a/src/ai/BotPlayer.js
+++ b/src/ai/BotPlayer.js
@@ -135,7 +135,7 @@ BotPlayer.prototype.update = function() { // Overrides the update function from 
                 this.food.push(check);
                 break;
             case 2: // Virus
-                this.virus.push(check);
+                if (!check.isMotherCell) this.virus.push(check); // Only real viruses! No mother cells
                 break;
             case 3: // Ejected mass
                 if (cell.mass > 20) {

--- a/src/ai/Readme.txt
+++ b/src/ai/Readme.txt
@@ -3,6 +3,9 @@ These bots are designed to be used for testing new commits of Ogar. To install t
 
 
 [Changelog]
+(1/18/16)
+- Bots won't recognize mother cells as viruses anymore
+
 (1/1/16)
 - Bot will now actively target the biggest prey
 

--- a/src/entity/Virus.js
+++ b/src/entity/Virus.js
@@ -6,6 +6,7 @@ function Virus() {
     this.cellType = 2;
     this.spiked = 1;
     this.fed = 0;
+    this.isMotherCell = false; // Not to confuse bots
 }
 
 module.exports = Virus;

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -143,6 +143,7 @@ function MotherCell() { // Temporary - Will be in its own file if Zeach decides 
     this.cellType = 2; // Copies virus cell
     this.color = {r: 205, g: 85, b: 100};
     this.spiked = 1;
+    this.isMotherCell = true; // Not to confuse bots
 }
 
 MotherCell.prototype = new Cell(); // Base


### PR DESCRIPTION
A simple fix to prevent bots from trying to pop enemies via mother cells.