### PR TITLE
Fix the 'Undefined, gameServer' bug when spawning food in Hunger Games

### DIFF
--- a/src/gamemodes/HungerGames.js
+++ b/src/gamemodes/HungerGames.js
@@ -79,7 +79,7 @@ HungerGames.prototype.getPos = function() {
 };
 
 HungerGames.prototype.spawnFood = function(gameServer, mass, pos) {
-    var f = new Entity.Food(gameServer.getNextNodeId(), null, pos, mass);
+    var f = new Entity.Food(gameServer.getNextNodeId(), null, pos, mass, gameServer);
     f.setColor(gameServer.getRandomColor());
     gameServer.addNode(f);
     gameServer.currentFood++;


### PR DESCRIPTION
There is an bug where gameServer is not defined when spawning the food