### PR TITLE
Collision, bot and Experimental updates

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -85,6 +85,7 @@ function GameServer() {
         playerMinMassDecay: 9, // Minimum mass for decay to occur
         playerMaxNickLength: 15, // Maximum nick length
         playerSpeed: 30, // Player base speed
+        playerSmoothSplit: 0, // Whether smooth splitting is used
         playerDisconnectTime: 60, // The amount of seconds it takes for a player cell to be removed after disconnection (If set to -1, cells are never removed)
         tourneyMaxPlayers: 12, // Maximum amount of participants for tournament style game modes
         tourneyPrepTime: 10, // Amount of ticks to wait after all players are ready (1 tick = 1000 ms)
@@ -637,7 +638,7 @@ GameServer.prototype.splitCells = function(client) {
         var split = new Entity.PlayerCell(this.getNextNodeId(), client, startPos, newMass);
         split.setAngle(angle);
         split.setMoveEngineData(splitSpeed, 12, 0.8);
-        split.ignoreCollision = true;
+        if (this.config.playerSmoothSplit == 1) split.ignoreCollision = true;
         split.calcMergeTime(this.config.playerRecombineTime);
 
         // Add to moving cells list

--- a/src/ai/Readme.txt
+++ b/src/ai/Readme.txt
@@ -1,8 +1,15 @@
 [Ogar player bots]
-These bots are designed to be used for testing new commits of Ogar. To install this module, set the serverBots config field in gameserver.js to an amount higher than 0 (10 is a good amount).
-
+These bots are designed to be used for testing new commits of Ogar.
+To install this module, set the serverBots config field in gameserver.js to an amount higher than 0 (10 is a good amount),
+or issue command addBots [number] in console.
 
 [Changelog]
+(1/27/16)
+- Bots' update function is triggered randomly (50 to 600 ms), to prevent massive update lag when having a lot of bots
+- Bots are a lot more aggressive
+- Bots will split even though more massive cells are near it
+[Planned] - Bots will target with their largest cell when chasing enemies, instead of smallest
+
 (1/18/16)
 - Bots won't recognize mother cells as viruses anymore
 

--- a/src/entity/Cell.js
+++ b/src/entity/Cell.js
@@ -59,7 +59,8 @@ Cell.prototype.getSquareSize = function() {
 Cell.prototype.addMass = function(n) {
     if (this.mass + n > this.owner.gameServer.config.playerMaxMass && this.owner.cells.length < this.owner.gameServer.config.playerMaxCells) {
         this.mass = (this.mass + n) / 2;
-        this.owner.gameServer.newCellVirused(this.owner, this, 0, this.mass, 150);
+        var randomAngle = Math.random() * 6.28 // Get random angle
+        this.owner.gameServer.newCellVirused(this.owner, this, randomAngle, this.mass);
     } else {
         this.mass = Math.min(this.mass + n, this.owner.gameServer.config.playerMaxMass);
     }

--- a/src/entity/PlayerCell.js
+++ b/src/entity/PlayerCell.js
@@ -77,7 +77,7 @@ PlayerCell.prototype.calcMove = function(x2, y2, gameServer) {
     for (var i = 0; i < this.owner.cells.length; i++) {
         var cell = this.owner.cells[i];
 
-        if ((this.nodeId == cell.nodeId) || (this.ignoreCollision)) {
+        if ((this.nodeId == cell.nodeId) || (this.ignoreCollision) || (cell.ignoreCollision)) {
             continue;
         }
 
@@ -89,11 +89,16 @@ PlayerCell.prototype.calcMove = function(x2, y2, gameServer) {
             // Calculations
             if (dist < collisionDist) { // Collided
                 // The moving cell pushes the colliding cell
+                // Strength however depends on cell1 speed divided by cell2 speed
+                var c1Speed = this.getSpeed();
+                var c2Speed = cell.getSpeed();
+                var mult = Math.min(Math.max(c1Speed / c2Speed, 2), 0.5); // Limit from 0.5 to 2, not to have bugs
+
                 var newDeltaY = y1 - cell.position.y;
                 var newDeltaX = x1 - cell.position.x;
-                var newAngle = Math.atan2(newDeltaX, newDeltaY);
 
-                var move = collisionDist - dist;
+                var newAngle = Math.atan2(newDeltaX, newDeltaY);
+                var move = (collisionDist - dist) * mult;
 
                 x1 = x1 + (move * Math.sin(newAngle)) >> 0;
                 y1 = y1 + (move * Math.cos(newAngle)) >> 0;
@@ -119,7 +124,7 @@ PlayerCell.prototype.calcMove = function(x2, y2, gameServer) {
 
     this.position.x = x1 >> 0;
     this.position.y = y1 >> 0;
-};
+}
 
 // Override
 

--- a/src/entity/Virus.js
+++ b/src/entity/Virus.js
@@ -71,14 +71,14 @@ Virus.prototype.onConsume = function(consumer, gameServer) {
     var angle = 0; // Starting angle
     for (var k = 0; k < numSplits; k++) {
         angle += 6 / numSplits; // Get directions of splitting cells
-        gameServer.newCellVirused(client, consumer, angle, splitMass, 150);
+        gameServer.newCellVirused(client, consumer, angle, splitMass);
         consumer.mass -= splitMass;
     }
 
     for (var k = 0; k < bigSplits; k++) {
         angle = Math.random() * 6.28; // Random directions
         splitMass = consumer.mass / 4;
-        gameServer.newCellVirused(client, consumer, angle, splitMass, 20);
+        gameServer.newCellVirused(client, consumer, angle, splitMass);
         consumer.mass -= splitMass;
     }
 

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -17,7 +17,7 @@ function Experimental() {
     this.tickMotherS = 0;
 
     // Config
-    this.motherCellMass = 200;
+    this.motherCellMass = 222;
     this.motherUpdateInterval = 5; // How many ticks it takes to update the mother cell (1 tick = 50 ms)
     this.motherSpawnInterval = 100; // How many ticks it takes to spawn another mother cell - Currently 5 seconds
     this.motherMinAmount = 5;
@@ -94,8 +94,8 @@ Experimental.prototype.onServerInit = function(gameServer) {
         gameServer.removeNode(feeder);
         // Pushes the virus
         this.setAngle(feeder.getAngle()); // Set direction if the virus explodes
-        this.moveEngineTicks = 5; // Amount of times to loop the movement function
-        this.moveEngineSpeed = 30;
+        this.moveEngineTicks += 10; // Amount of times to loop the movement function
+        this.moveEngineSpeed += 28;
 
         var index = gameServer.movingNodes.indexOf(this);
         if (index == -1) {
@@ -109,12 +109,7 @@ Experimental.prototype.onServerInit = function(gameServer) {
 
 Experimental.prototype.onTick = function(gameServer) {
     // Mother Cell updates
-    if (this.tickMother >= this.motherUpdateInterval) {
-        this.updateMotherCells(gameServer);
-        this.tickMother = 0;
-    } else {
-        this.tickMother++;
-    }
+    this.updateMotherCells(gameServer);
 
     // Mother Cell Spawning
     if (this.tickMotherS >= this.motherSpawnInterval) {
@@ -153,30 +148,40 @@ function MotherCell() { // Temporary - Will be in its own file if Zeach decides 
 MotherCell.prototype = new Cell(); // Base
 
 MotherCell.prototype.getEatingRange = function() {
-    return this.getSize() * .5;
+    return this.getSize() / 3.14;
 };
 
 MotherCell.prototype.update = function(gameServer) {
-    // Add mass
-    this.mass += .25;
+    if (Math.random() * 100 > 97) {
+        var maxFood = Math.random() * 2; // Max food spawned per tick
+        var i = 0; // Food spawn counter
+        while (i < maxFood)  {
+            // Only spawn if food cap hasn't been reached
+            if (gameServer.currentFood < gameServer.config.foodMaxAmount * 1.5) {
+                this.spawnFood(gameServer);
+            }
 
-    // Spawn food
-    var maxFood = 10; // Max food spawned per tick
-    var i = 0; // Food spawn counter
-    while ((this.mass > gameServer.gameMode.motherCellMass) && (i < maxFood)) {
-        // Only spawn if food cap hasn been reached
-        if (gameServer.currentFood < gameServer.config.foodMaxAmount) {
-            this.spawnFood(gameServer);
+            // Increment
+            i++;
         }
-
-        // Incrementers
-        this.mass--;
-        i++;
+    }
+    if (this.mass > 222) {
+        // Always spawn food if the mother cell is larger than 222
+        var cellSize = gameServer.config.foodMass;
+        if (this.mass > 222 + cellSize * 2) { // Spawn it twice if possible
+            this.spawnFood(gameServer);
+            this.spawnFood(gameServer);
+            this.mass -= cellSize;
+            this.mass -= cellSize;
+        } else if (this.mass > 222 + cellSize) {
+            this.spawnFood(gameServer);
+            this.mass -= cellSize;
+        }
     }
 };
 
 MotherCell.prototype.checkEat = function(gameServer) {
-    var safeMass = this.mass * .9;
+    var safeMass = this.mass * .78;
     var r = this.getSize(); // The box area that the checked cell needs to be in to be considered eaten
 
     // Loop for potential prey

--- a/src/gamemodes/Teams.js
+++ b/src/gamemodes/Teams.js
@@ -110,22 +110,21 @@ Teams.prototype.onCellMove = function(x1, y1, cell) {
         if (check.owner.getTeam() == team) {
             // Check if in collision range
             var collisionDist = check.getSize() + r; // Minimum distance between the 2 cells
-            if (!cell.simpleCollide(x1, y1, check, collisionDist)) {
-                // Skip
-                continue;
-            }
-
-            // First collision check passed... now more precise checking
-            dist = cell.getDist(cell.position.x, cell.position.y, check.position.x, check.position.y);
+            var dist = cell.getDist(cell.position.x, cell.position.y, check.position.x, check.position.y);
 
             // Calculations
             if (dist < collisionDist) { // Collided
                 // The moving cell pushes the colliding cell
+                // Strength however depends on cell1 speed divided by cell2 speed
+                var speed1 = cell.getSpeed();
+                var speed2 = check.getSpeed();
+                var mult = Math.min(Math.max(speed1 / speed2, 2), 0.5); // Limit from 0.5 to 2 not to have bugs
+
                 var newDeltaY = check.position.y - y1;
                 var newDeltaX = check.position.x - x1;
                 var newAngle = Math.atan2(newDeltaX, newDeltaY);
 
-                var move = collisionDist - dist;
+                var move = (collisionDist - dist) * mult;
 
                 check.position.x = check.position.x + (move * Math.sin(newAngle)) >> 0;
                 check.position.y = check.position.y + (move * Math.cos(newAngle)) >> 0;

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -10,7 +10,7 @@
 // serverLogLevel: Logging level of the server. 0 = No logs, 1 = Logs the console, 2 = Logs console and ip connections
 // serverScrambleCoords: Toggles scrambling of coordinates. 0 = No scrambling, 1 = scrambling. Default is 1.
 serverMaxConnections = 64
-serverPort = 443
+serverPort = 420
 serverGamemode = 0
 serverBots = 0
 serverViewBaseX = 1024
@@ -23,23 +23,23 @@ serverScrambleCoords = 1
 // [Border]
 // Border values of the map (Vanilla values are left/top = 0, right/bottom = 11180.3398875)
 borderLeft = 0
-borderRight = 6000
+borderRight = 11180.3398875
 borderTop = 0
-borderBottom = 6000
+borderBottom = 11180.3398875
 
 // [Spawn]
 // Each interval is 1 tick (50 ms)
-spawnInterval = 20
+spawnInterval = 1
 foodSpawnAmount = 10
-foodStartAmount = 100
-foodMaxAmount = 500
+foodStartAmount = 1500
+foodMaxAmount = 1700
 foodMass = 1
 foodMassGrow = 1
 foodMassGrowPossiblity = 50
 foodMassLimit = 5
 foodMassTimeout = 120
-virusMinAmount = 10
-virusMaxAmount = 50
+virusMinAmount = 30
+virusMaxAmount = 120
 virusStartMass = 100
 virusFeedAmount = 7
 
@@ -50,7 +50,7 @@ virusFeedAmount = 7
 // ejectSpeed: Base speed of ejected cells
 // ejectSpawnPlayer: Chance for a player to spawn from ejected mass
 ejectMass = 12
-ejectMassCooldown = 200
+ejectMassCooldown = 0
 ejectMassLoss = 16
 ejectSpeed = 160
 ejectSpawnPlayer = 50
@@ -60,17 +60,19 @@ ejectSpawnPlayer = 50
 // playerMassDecayRate: Amount of mass lost per tick (Multiplier) (1 tick = 1000 milliseconds)
 // playerMinMassDecay: Minimum mass for decay to occur
 // playerDisconnectTime: The amount of seconds it takes for a player cell to be removed after disconnection (If set to -1, cells are never removed)
-playerStartMass = 10
+// playerSmoothSplit: Set to 1 for smooth splitting.
+playerStartMass = 100
 playerMaxMass = 22500
 playerMinMassEject = 32
 playerMinMassSplit = 36
 playerMaxCells = 16
-playerRecombineTime = 30
-playerMassDecayRate = .002
+playerRecombineTime = 10
+playerMassDecayRate = 0.002
 playerMinMassDecay = 9
 playerMaxNickLength = 15
 playerSpeed = 30
 playerDisconnectTime = 60
+playerSmoothSplit = 0
 
 // [Gamemode]
 // Custom gamemode settings
@@ -83,4 +85,3 @@ tourneyEndTime = 30
 tourneyTimeLimit = 20
 tourneyAutoFill = 0
 tourneyAutoFillPlayers = 1
-

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -10,7 +10,7 @@
 // serverLogLevel: Logging level of the server. 0 = No logs, 1 = Logs the console, 2 = Logs console and ip connections
 // serverScrambleCoords: Toggles scrambling of coordinates. 0 = No scrambling, 1 = scrambling. Default is 1.
 serverMaxConnections = 64
-serverPort = 420
+serverPort = 443
 serverGamemode = 0
 serverBots = 0
 serverViewBaseX = 1024
@@ -23,23 +23,23 @@ serverScrambleCoords = 1
 // [Border]
 // Border values of the map (Vanilla values are left/top = 0, right/bottom = 11180.3398875)
 borderLeft = 0
-borderRight = 11180.3398875
+borderRight = 6000
 borderTop = 0
-borderBottom = 11180.3398875
+borderBottom = 6000
 
 // [Spawn]
 // Each interval is 1 tick (50 ms)
-spawnInterval = 1
+spawnInterval = 20
 foodSpawnAmount = 10
-foodStartAmount = 1500
-foodMaxAmount = 1700
+foodStartAmount = 100
+foodMaxAmount = 500
 foodMass = 1
 foodMassGrow = 1
 foodMassGrowPossiblity = 50
 foodMassLimit = 5
 foodMassTimeout = 120
-virusMinAmount = 30
-virusMaxAmount = 120
+virusMinAmount = 10
+virusMaxAmount = 50
 virusStartMass = 100
 virusFeedAmount = 7
 
@@ -50,7 +50,7 @@ virusFeedAmount = 7
 // ejectSpeed: Base speed of ejected cells
 // ejectSpawnPlayer: Chance for a player to spawn from ejected mass
 ejectMass = 12
-ejectMassCooldown = 0
+ejectMassCooldown = 200
 ejectMassLoss = 16
 ejectSpeed = 160
 ejectSpawnPlayer = 50
@@ -61,13 +61,13 @@ ejectSpawnPlayer = 50
 // playerMinMassDecay: Minimum mass for decay to occur
 // playerDisconnectTime: The amount of seconds it takes for a player cell to be removed after disconnection (If set to -1, cells are never removed)
 // playerSmoothSplit: Set to 1 for smooth splitting.
-playerStartMass = 100
+playerStartMass = 10
 playerMaxMass = 22500
 playerMinMassEject = 32
 playerMinMassSplit = 36
 playerMaxCells = 16
-playerRecombineTime = 10
-playerMassDecayRate = 0.002
+playerRecombineTime = 30
+playerMassDecayRate = .002
 playerMinMassDecay = 9
 playerMaxNickLength = 15
 playerSpeed = 30


### PR DESCRIPTION
- newCellVirused function will use its own speed
- ignoreCollision on split cells
- Updates on cells occurs every 50 ms instead of 1 second
- Update cell collision on own cells and Experimental
- Random angle on auto split
- Remove speed indicators when exploding cells with viruses (look up)
- Multiplier on eating cells is now `1.33`
- Pushing viruses in Experimental is more accurate to Agar.io
- Mother cell is more accurate to Agar.io
- Mother cells will almost always passively release food
- Update on bots
  - Bots' update function is triggered randomly (50 to 600 ms), to prevent massive update lag when having a lot of bots
  - Bots are a lot more aggressive
  - Bots will split even though more massive cells are near it
    [Planned] - Bots will target with their largest cell when chasing enemies, instead of smallest

**However** we now have a problem: cells smooth splitting with ignoreCollision is too slow.
