### PR TITLE
Disable anti-teaming by default

### DIFF
--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -21,7 +21,7 @@ serverStatsPort = 88
 serverStatsUpdate = 60
 serverLogLevel = 1
 serverScrambleCoords = 1
-serverTeamingAllowed = 0
+serverTeamingAllowed = 1
 serverMaxLB = 10
 
 // [Border]


### PR DESCRIPTION
This changes the default to be the old behavior of the ogar server, which is safer for people upgrading to the newer version.