### PR TITLE
Disable anti-teaming by default

### DIFF
--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -9,7 +9,7 @@
 // serverStatsUpdate: Amount of seconds per update for server stats
 // serverLogLevel: Logging level of the server. 0 = No logs, 1 = Logs the console, 2 = Logs console and ip connections
 // serverScrambleCoords: Toggles scrambling of coordinates. 0 = No scrambling, 1 = scrambling. Default is 1.
-// serverTeamingAllowed: Toggles anti-teaming. 0 = Anti-team enabled, 1 = Anti-team disabled. Default is 0.
+// serverTeamingAllowed: Toggles anti-teaming. 0 = Anti-team enabled, 1 = Anti-team disabled. Default is 1.
 // serverMaxLB: Controls the maximum players displayed on the leaderboard.
 serverMaxConnections = 64
 serverPort = 443
@@ -21,7 +21,7 @@ serverStatsPort = 88
 serverStatsUpdate = 60
 serverLogLevel = 1
 serverScrambleCoords = 1
-serverTeamingAllowed = 0
+serverTeamingAllowed = 1
 serverMaxLB = 10
 
 // [Border]


### PR DESCRIPTION
This changes the default to be the old behavior of the ogar server, which is safer for people upgrading to the newer version.