### PR TITLE
Update GameServer.js anti-team default to match config file

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -54,7 +54,7 @@ function GameServer() {
         serverStatsUpdate: 60, // Amount of seconds per update for the server stats
         serverLogLevel: 1, // Logging level of the server. 0 = No logs, 1 = Logs the console, 2 = Logs console and ip connections
         serverScrambleCoords: 1, // Toggles scrambling of coordinates. 0 = No scrambling, 1 = scrambling. Default is 1.
-        serverTeamingAllowed: 0, // Toggles anti-teaming. 0 = Anti-team enabled, 1 = Anti-team disabled
+        serverTeamingAllowed: 1, // Toggles anti-teaming. 0 = Anti-team enabled, 1 = Anti-team disabled
         serverMaxLB: 10, //	Controls the maximum players displayed on the leaderboard.
         borderLeft: 0, // Left border of map (Vanilla value: 0)
         borderRight: 6000, // Right border of map (Vanilla value: 11180.3398875)


### PR DESCRIPTION
If the config file is missing on server startup, *both* configs now default to anti-teaming off.

This extends #437 