### PR TITLE
Feature: optional mass absorbtion inefficiency

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -84,6 +84,7 @@ function GameServer() {
         playerMinMassSplit: 36, // Mass required to split
         playerMaxCells: 16, // Max cells the player is allowed to have
         playerRecombineTime: 30, // Base amount of seconds before a cell is allowed to recombine
+        playerMassAbsorbed: 1.0, // Fraction of player cell's mass gained upon eating
         playerMassDecayRate: .002, // Amount of mass lost per second
         playerMinMassDecay: 9, // Minimum mass for decay to occur
         playerMaxNickLength: 15, // Maximum nick length

--- a/src/entity/PlayerCell.js
+++ b/src/entity/PlayerCell.js
@@ -136,7 +136,9 @@ PlayerCell.prototype.getEatingRange = function() {
 };
 
 PlayerCell.prototype.onConsume = function(consumer, gameServer) {
-    consumer.addMass(this.mass);
+    // Add an inefficiency for eating other players' cells
+    var factor = ( consumer.owner === this.owner ? 1 : gameServer.config.playerMassAbsorbed );
+    consumer.addMass(factor * this.mass);
 };
 
 PlayerCell.prototype.onAdd = function(gameServer) {

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -61,6 +61,7 @@ ejectSpawnPlayer = 50
 
 // [Player]
 // playerRecombineTime: Base amount of ticks before a cell is allowed to recombine (1 tick = 1000 milliseconds)
+// playerMassAbsorbed: Fraction of a player cell that gets absorbed upon eating (i.e., 1 = 100%, 0.8 = 80%, etc)
 // playerMassDecayRate: Amount of mass lost per tick (Multiplier) (1 tick = 1000 milliseconds)
 // playerMinMassDecay: Minimum mass for decay to occur
 // playerDisconnectTime: The amount of seconds it takes for a player cell to be removed after disconnection (If set to -1, cells are never removed)
@@ -71,6 +72,7 @@ playerMinMassEject = 32
 playerMinMassSplit = 36
 playerMaxCells = 16
 playerRecombineTime = 30
+playerMassAbsorbed = 1.0
 playerMassDecayRate = .002
 playerMinMassDecay = 9
 playerMaxNickLength = 15


### PR DESCRIPTION
This is an optional anti-teaming mechanism (not same as #433).  Default value does not change existing behaviour.

The admin may configure the server such that when a `Alice` eats `Bob`'s cell, `Alice` only gains a fraction of `Bob`'s cell's mass.  Therefore, teaming behaviours like split-running, trick-splitting, etc., become less effective, without the possibility of accidentally triggering a "punishment" mechanism.

The default value is `1.0` (i.e., 100%).  A good value for anti teaming, for example, would be `0.8` (i.e., 80%).