### PR TITLE
Bug fixes & two new commands

### DIFF
--- a/src/PacketHandler.js
+++ b/src/PacketHandler.js
@@ -59,7 +59,6 @@ PacketHandler.prototype.handleMessage = function(message) {
             // Spectate mode
             if (this.socket.playerTracker.cells.length <= 0) {
                 // Make sure client has no cells
-                this.gameServer.switchSpectator(this.socket.playerTracker);
                 this.socket.playerTracker.spectate = true;
             }
             break;

--- a/src/entity/Cell.js
+++ b/src/entity/Cell.js
@@ -147,34 +147,36 @@ Cell.prototype.calcMovePhys = function(config) {
     // Movement engine
     this.moveEngineSpeed *= this.moveDecay; // Decaying speed
     this.moveEngineTicks--;
-
+    
     // Ejected cell collision
-    for (var i = 0; i < this.gameServer.nodesEjected.length; i++) {
-        var check = this.gameServer.nodesEjected[i];
-
-        if (check.nodeId == this.nodeId) continue; // Don't check for yourself
-
-        var dist = this.getDist(this.position.x, this.position.y, check.position.x, check.position.y);
-        var allowDist = (this.getSize() + check.getSize()) * 0.95; // Allow cells to get in themselves a bit
-
-        if (dist < allowDist) {
-            // Two ejected cells collided
-            var deltaX = this.position.x - check.position.x;
-            var deltaY = this.position.y - check.position.y;
-            var angle = Math.atan2(deltaX, deltaY);
-
-            check.moveEngineTicks++;
-            if (this.gameServer.movingNodes.indexOf(check) == -1) this.gameServer.setAsMovingNode(check);
-
-            this.moveEngineTicks++;
-
-            // Make sure they don't become a living organism (wait, a multicellular organism simulator!)
-            var realAD = (this.getSize() + check.getSize()) * 1.05;
-
-            var move = (realAD - dist) / 2;
-
-            X += (Math.sin(angle) * move) >> 0;
-            Y += (Math.cos(angle) * move) >> 0;
+    if (this.cellType == 3) {
+        for (var i = 0; i < this.gameServer.nodesEjected.length; i++) {
+            var check = this.gameServer.nodesEjected[i];
+            
+            if (check.nodeId == this.nodeId) continue; // Don't check for yourself
+            
+            var dist = this.getDist(this.position.x, this.position.y, check.position.x, check.position.y);
+            var allowDist = (this.getSize() + check.getSize()) * 0.95; // Allow cells to get in themselves a bit
+            
+            if (dist < allowDist) {
+                // Two ejected cells collided
+                var deltaX = this.position.x - check.position.x;
+                var deltaY = this.position.y - check.position.y;
+                var angle = Math.atan2(deltaX, deltaY);
+                
+                check.moveEngineTicks++;
+                if (this.gameServer.movingNodes.indexOf(check) == -1) this.gameServer.setAsMovingNode(check);
+                
+                this.moveEngineTicks++;
+                
+                // Make sure they don't become a living organism (wait, a multicellular organism simulator!)
+                var realAD = (this.getSize() + check.getSize()) * 1.2;
+                
+                var move = (realAD - dist) / 2;
+                
+                X += (Math.sin(angle) * move) >> 0;
+                Y += (Math.cos(angle) * move) >> 0;
+            }
         }
     }
 

--- a/src/entity/EjectedMass.js
+++ b/src/entity/EjectedMass.js
@@ -20,6 +20,7 @@ EjectedMass.prototype.addMass = function(n) {
     return; // Do nothing, this is an ejected cell
 };
 
+
 // Cell-specific functions
 EjectedMass.prototype.getSize = function() {
     return this.size;
@@ -41,18 +42,20 @@ EjectedMass.prototype.sendUpdate = function() {
 
 EjectedMass.prototype.onRemove = function(gameServer) {
     // Check for teaming and apply anti-teaming if required
-    if (this.gameServer.gameMode.teamAmount > 0) {
-        // Apply teaming EXCEPT when exchanging mass to same team member
-        if (this.owner.team != this.killedBy.owner.team || this.owner == this.killedBy.owner) {
+    try {
+        if (this.gameServer.gameMode.teamAmount > 0) {
+            // Apply teaming EXCEPT when exchanging mass to same team member
+            if (this.owner.team != this.killedBy.owner.team || this.owner == this.killedBy.owner) {
+                this.owner.actionMult += 0.02;
+                this.owner.actionDecayMult *= 1.0005;
+            };
+        } else {
+            // Always apply anti-teaming if there are no teams
             this.owner.actionMult += 0.02;
             this.owner.actionDecayMult *= 1.0005;
         };
-    } else {
-        // Always apply anti-teaming if there are no teams
-        this.owner.actionMult += 0.02;
-        this.owner.actionDecayMult *= 1.0005;
-    };
-
+    } catch(ex) { } // Dont do anything whatever the error is
+    
     // Remove from list of ejected mass
     var index = gameServer.nodesEjected.indexOf(this);
     if (index != -1) {

--- a/src/modules/CommandList.js
+++ b/src/modules/CommandList.js
@@ -40,10 +40,12 @@ Commands.list = {
         console.log("[Console] kill [PlayerID]              : kill cell(s) by client ID");
         console.log("[Console] killall                      : kill everyone");
         console.log("[Console] mass [PlayerID] [mass]       : set cell(s) mass by client ID");
+        console.log("[Console] merge [PlayerID] (state)     : merge all client's cells once by state");
         console.log("[Console] name [PlayerID] [name]       : change cell(s) name by client ID");
         console.log("[Console] playerlist                   : get list of players and bots");
         console.log("[Console] pause                        : pause game , freeze all cells");
         console.log("[Console] reload                       : reload config");
+        console.log("[Console] resetantiteam [PlayerID]     : reset anti-team effect on client");
         console.log("[Console] status                       : get server status");
         console.log("[Console] tp [PlayerID] [X] [Y]        : teleport player to specified location");
         console.log("[Console] virus [X] [Y] [mass]         : spawn virus at a specified Location");
@@ -279,6 +281,36 @@ Commands.list = {
             }
         }
     },
+    merge: function(gameServer, split) {
+        // Validation checks
+        var id = parseInt(split[1]) - 1;
+        var realId = id + 1;
+        var set = split[2];
+        if (isNaN(id)) {
+            console.log("[Console] Please specify a valid player ID!");
+            return;
+        }
+
+        if (!gameServer.clients[id]) {
+            console.log("[Console] Client is nonexistent!");
+            return;
+        }
+        var client = gameServer.clients[id].playerTracker;
+
+        if (!isNaN(set)) {
+            if (set == "true") {
+                client.mergeOverride = true;
+                console.log("[Console] Player " + realId + " is now force merging");
+            }
+            if (set == "false") {
+                client.mergeOverride = false;
+                console.log("[Console] Player " + realId + " isn't force merging anymore");
+            }
+        } else {
+            client.mergeOverride = true;
+            console.log("[Console] Player " + realId + " is now force merging");
+        }
+    },
     name: function(gameServer, split) {
         // Validation checks
         var id = parseInt(split[1]);
@@ -295,7 +327,7 @@ Commands.list = {
 
         // Change name
         for (var i = 0; i < gameServer.clients.length; i++) {
-            var client = gameServer.clients[i].playerTracker;
+            var client = gameServer.clients[id + 1].playerTracker;
 
             if (client.pID == id) {
                 console.log("[Console] Changing " + client.name + " to " + name);
@@ -332,15 +364,10 @@ Commands.list = {
                 data = '';
             if (client.spectate) {
                 try {
-                    // Get spectated player
-                    if (gameServer.getMode().specByLeaderboard) { // Get spec type
-                        nick = gameServer.leaderboard[client.spectatedPlayer].name;
-                    } else {
-                        nick = gameServer.clients[client.spectatedPlayer].playerTracker.name;
-                    }
+                    nick = gameServer.largestClient.name;
                 } catch (e) {
-                    // Specating nobody
-                    nick = "";
+                    // Specating in free-roam mode
+                    nick = "in free-roam";
                 }
                 nick = (nick == "") ? "An unnamed cell" : nick;
                 data = fillChar("SPECTATING: " + nick, '-', ' | CELLS | SCORE  | POSITION    '.length + gameServer.config.playerMaxNickLength, true);
@@ -367,6 +394,24 @@ Commands.list = {
         gameServer.loadConfig();
         console.log("[Console] Reloaded the config file successfully");
     },
+    resetantiteam: function(gameServer, split) {
+        // Validation checks
+        var id = parseInt(split[1]);
+        if (isNaN(id)) {
+            console.log("[Console] Please specify a valid player ID!");
+            return;
+        }
+
+        if (!gameServer.clients[id]) {
+            console.log("[Console] Client is nonexistent!");
+            return;
+        }
+
+        gameServer.clients[id].playerTracker.massDecayMult = 1;
+        gameServer.clients[id].playerTracker.actionMult = 0;
+        gameServer.clients[id].playerTracker.actionDecayMult = 1;
+        console.log("[Console] Successfully reset client's anti-team effect");
+    },
     status: function(gameServer, split) {
         // Get amount of humans/bots
         var humans = 0,
@@ -380,8 +425,8 @@ Commands.list = {
         }
         //
         console.log("[Console] Connected players: " + gameServer.clients.length + "/" + gameServer.config.serverMaxConnections);
-        console.log("[Console] Players: " + humans + " Bots: " + bots);
-        console.log("[Console] Server has been running for " + process.uptime() + " seconds.");
+        console.log("[Console] Players: " + humans + " - Bots: " + bots);
+        console.log("[Console] Server has been running for " + process.uptime() + " seconds");
         console.log("[Console] Current memory usage: " + process.memoryUsage().heapUsed / 1000 + "/" + process.memoryUsage().heapTotal / 1000 + " kb");
         console.log("[Console] Current game mode: " + gameServer.gameMode.name);
     },


### PR DESCRIPTION
**`PlayerTracker.js`**
- `getSpectateNodes` was fractured into 3 functions
- Shortened length of code at `!this.freeRoam`  _(remember the mess?)_
- Fix bug where no nodes are returned (you'll be in free-roam until a player gets in)

**`GameServer.js`**
- Remove `switchSpectator` function as it's useless after free-roam update
- Apply forced merge command

**`PacketHandler.js`**
- Remove `switchSpectator(...)` call as it's useless after free-roam update

**`Cell.js`**
- Fix bug where player cell is pushed from ejected cell

**`EjectedMass.js`**
- Add a try block in any case at node removal  _(because I got an error pointing there a few hours ago)_

**`CommandList.js (new commands)`**
- `merge [PlayerID] (state)` : merge all client's cells once by state (note that `state` variable is optional)
- `resetantiteam [PlayerID]` : reset anti-team effect on client