### PR TITLE
Double collision check and more tweaks

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -401,6 +401,8 @@ GameServer.prototype.mainLoop = function() {
     var local = new Date();
     this.tick += (local - this.time);
     this.time = local;
+    
+    if (!this.run) return;
 
     if (this.tick >= 25) {
         this.fullTick++;
@@ -408,11 +410,9 @@ GameServer.prototype.mainLoop = function() {
 
         if (this.fullTick >= 2) {
             // Loop main functions
-            if (this.run) {
-                setTimeout(this.spawnTick(), 0);
-                setTimeout(this.gamemodeTick(), 0);
-                setTimeout(this.cellUpdateTick(), 0);
-            }
+            setTimeout(this.spawnTick(), 0);
+            setTimeout(this.gamemodeTick(), 0);
+            setTimeout(this.cellUpdateTick(), 0);
 
             // Update the client's maps
             this.updateClients();

--- a/src/entity/Cell.js
+++ b/src/entity/Cell.js
@@ -144,14 +144,15 @@ Cell.prototype.visibleCheck = function(box, centerPos) {
 };
 
 Cell.prototype.calcMovePhys = function(config) {
-    // Movement for ejected cells
-    var X = this.position.x + (this.moveEngineSpeed * Math.sin(this.angle));
-    var Y = this.position.y + (this.moveEngineSpeed * Math.cos(this.angle));
+    // Move, twice as slower
+    var X = this.position.x + ((this.moveEngineSpeed / 2) * Math.sin(this.angle));
+    var Y = this.position.y + ((this.moveEngineSpeed / 2) * Math.cos(this.angle));
 
     // Movement engine
-    if (this.moveEngineSpeed <= this.moveDecay * 8.5) this.moveEngineSpeed = 0;
-    this.moveEngineSpeed *= this.moveDecay; // Decaying speed
-    this.moveEngineTicks--;
+    if (this.moveEngineSpeed <= this.moveDecay * 3) this.moveEngineSpeed = 0;
+    var speedDecrease = this.moveEngineSpeed - this.moveEngineSpeed * this.moveDecay;
+    this.moveEngineSpeed -= speedDecrease / 2; // Decaying speed twice as slower
+    this.moveEngineTicks -= 0.5; // Ticks passing twice as slower
 
     // Ejected cell collision
     if (this.cellType == 3) {
@@ -175,7 +176,7 @@ Cell.prototype.calcMovePhys = function(config) {
                 this.moveEngineTicks++;
 
                 // Make sure they don't become a living organism (wait, a multicellular organism simulator!)
-                var realAD = (this.getSize() + check.getSize()) * 1.2;
+                var realAD = (this.getSize() + check.getSize()) * 1.1;
 
                 var move = (realAD - dist) / 2;
 

--- a/src/entity/Virus.js
+++ b/src/entity/Virus.js
@@ -15,7 +15,7 @@ Virus.prototype = new Cell();
 Virus.prototype.calcMove = null; // Only for player controlled movement
 
 Virus.prototype.feed = function(feeder, gameServer) {
-    this.setAngle(feeder.getAngle()); // Set direction if the virus explodes
+    if (this.moveEngineTicks == 0) this.setAngle(feeder.getAngle()); // Set direction if the virus explodes
     this.mass += feeder.mass;
     this.fed++; // Increase feed count
     gameServer.removeNode(feeder);

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -247,7 +247,7 @@ MotherCell.prototype.spawnFood = function(gameServer) {
 
     // Move engine
     f.angle = angle;
-    var dist = (Math.random() * 10) + 5; // Random distance
+    var dist = (Math.random() * 8) + 8; // Random distance
     f.setMoveEngineData(dist, 20, 0.85);
 
     gameServer.setAsMovingNode(f);

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -53,10 +53,10 @@ virusFeedAmount = 7
 // ejectMassLoss: Mass lost when ejecting cells
 // ejectSpeed: Base speed of ejected cells
 // ejectSpawnPlayer: Chance for a player to spawn from ejected mass
-ejectMass = 12
+ejectMass = 13
 ejectMassCooldown = 200
-ejectMassLoss = 16
-ejectSpeed = 160
+ejectMassLoss = 15
+ejectSpeed = 100
 ejectSpawnPlayer = 50
 
 // [Player]
@@ -78,7 +78,7 @@ playerMinMassDecay = 9
 playerMaxNickLength = 15
 playerSpeed = 30
 playerDisconnectTime = 60
-playerSmoothSplit = 0
+playerSmoothSplit = 1
 
 // [Gamemode]
 // Custom gamemode settings


### PR DESCRIPTION
Instead of checking in-between move when updating move engine, why not just check for collision twice?
- `gameserver.ini` Refactor ejected cell settings to default agar.io
- `GameServer.js` Double collision check update + base config edits
- `PlayerTracker.js` Remove merge override & few anti-teaming tweaks
- `Experimental.js` Fix mothercell pellets being way too close
- `Cell.js` Double collision check update at calcMovePhys
- `PlayerCell.js` Double double collision with player cells; cell now even moves other cell _(Fixes small cells going through big ones partially)_
- `Virus.js` Fix virus changing angle when feeding while moving

**P.S. popsplitting might be possible now, haven't tried**
**P.P.S. team collisions are still 50 ms and aren't double-sided**