### PR TITLE
Eased merging, few anti-teaming tweaks and collision update

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -900,6 +900,9 @@ GameServer.prototype.getCellsInRange = function(cell) {
                     }
                 }
                 break;
+            case 2:
+                multiplier = 1.32;
+                break;
             default:
                 break;
         }

--- a/src/PlayerTracker.js
+++ b/src/PlayerTracker.js
@@ -234,9 +234,9 @@ PlayerTracker.prototype.antiTeamTick = function() {
     // ANTI-TEAMING DECAY
     // Calculated even if anti-teaming is disabled.
     var effectSum = this.Wmult + this.virusMult + this.splittingMult;
-    if (this.Wmult - 0.0007 > 0) this.Wmult -= 0.0007;
-    this.virusMult *= 0.998;
-    this.splittingMult *= 0.996;
+    if (this.Wmult - 0.0008 > 0) this.Wmult -= 0.0008;
+    this.virusMult *= 0.9985;
+    this.splittingMult *= 0.9977;
     // Apply anti-teaming if required
     if (effectSum > 1) this.massDecayMult = Math.min(effectSum, 2.5);
     else this.massDecayMult = 1;

--- a/src/gamemodes/Teams.js
+++ b/src/gamemodes/Teams.js
@@ -93,7 +93,7 @@ Teams.prototype.onCellRemove = function(cell) {
     }
 };
 
-Teams.prototype.onCellMove = function(x1, y1, cell) {
+Teams.prototype.onCellMove = function(cell, gameServer) {
     var team = cell.owner.getTeam();
     var r = cell.getSize();
 
@@ -108,32 +108,15 @@ Teams.prototype.onCellMove = function(x1, y1, cell) {
 
         // Collision with teammates
         if (check.owner.getTeam() == team) {
-            // Check if in collision range
-            var collisionDist = check.getSize() + r; // Minimum distance between the 2 cells
-            var dist = cell.getDist(cell.position.x, cell.position.y, check.position.x, check.position.y);
+            var calcInfo = gameServer.checkCellCollision(cell, check); // Calculation info
 
-            // Calculations
-            if (dist < collisionDist) { // Collided
-                // The moving cell pushes the colliding cell
-                // Strength however depends on cell1 speed divided by cell2 speed
+            // Further calculations
+            if (calcInfo.collided) { // Collided
+                // Cell with collision restore ticks on should not collide
+                if (cell.collisionRestoreTicks > 0 || check.collisionRestoreTicks > 0) continue;
 
-                // Note that the collision is actually inversed, cell we're cheking will be moved,
-                // so make sure we're looking in check's perspective
-                var c2Speed = cell.getSpeed();
-                var c1Speed = check.getSpeed();
-
-                var mult = c1Speed / c2Speed / 2;
-                if (mult < 0.15) mult = 0.15;
-                if (mult > 0.9) mult = 0.9;
-
-                var newDeltaY = check.position.y - y1;
-                var newDeltaX = check.position.x - x1;
-                var newAngle = Math.atan2(newDeltaX, newDeltaY);
-
-                var move = (collisionDist - dist) * mult;
-
-                check.position.x = check.position.x + (move * Math.sin(newAngle)) >> 0;
-                check.position.y = check.position.y + (move * Math.cos(newAngle)) >> 0;
+                // Call gameserver's function to collide cells
+                gameServer.cellCollision(cell, check, calcInfo);
             }
         }
     }

--- a/src/modules/CommandList.js
+++ b/src/modules/CommandList.js
@@ -45,7 +45,7 @@ Commands.list = {
         console.log("[Console] playerlist                   : get list of players and bots");
         console.log("[Console] pause                        : pause game , freeze all cells");
         console.log("[Console] reload                       : reload config");
-        console.log("[Console] resetantiteam                : reset anti-team effect on client");
+        console.log("[Console] resetantiteam [PlayerID]     : reset anti-team effect on client");
         console.log("[Console] status                       : get server status");
         console.log("[Console] tp [PlayerID] [X] [Y]        : teleport player to specified location");
         console.log("[Console] virus [X] [Y] [mass]         : spawn virus at a specified Location");
@@ -421,15 +421,20 @@ Commands.list = {
             return;
         }
 
-        if (!gameServer.clients[id]) {
-            console.log("[Console] Client is nonexistent!");
-            return;
-        }
+        for (var i in gameServer.clients) {
+            var client = gameServer.clients[i];
+            if (!client) continue; // Nonexistent
 
-        gameServer.clients[id].playerTracker.massDecayMult = 1;
-        gameServer.clients[id].playerTracker.actionMult = 0;
-        gameServer.clients[id].playerTracker.actionDecayMult = 1;
-        console.log("[Console] Successfully reset client's anti-team effect");
+            if (client.playerTracker.pID == id) {
+                // Found client
+                client.playerTracker.massDecayMult = 1;
+                client.playerTracker.Wmult = 0;
+                client.playerTracker.virusMult = 0;
+                client.playerTracker.splittingMult = 0;
+                console.log("[Console] Successfully reset client's anti-team effect");
+                return;
+            }
+        }
     },
     status: function(gameServer, split) {
         // Get amount of humans/bots


### PR DESCRIPTION
- Cell collision is now made in GameServer, and is automatically friendly to new gamemodes. This update doesn't affect ejected cells
- Cell eating multiplier is now 1.3 (10000 mass should eat 6666 mass cell)
- Small cells won't explode out of a lot larger cells (was visible when exploding with 5000+ mass)
- `collisionCheck2` will be used only with pellets, also **eased merging**!
- Fix `resetantiteam` command not working
- Anti-teaming decay divisor increased to 570
- Anti-teaming punisment is longer than before

oh and one cool bug: enabling forced merge and autosplitting will result in a maching xD
