### PR TITLE
Anti-teaming tweaks & reflect updates from agar.io

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -55,6 +55,7 @@ function GameServer() {
         serverStatsUpdate: 60, // Amount of seconds per update for the server stats
         serverLogLevel: 1, // Logging level of the server. 0 = No logs, 1 = Logs the console, 2 = Logs console and ip connections
         serverScrambleCoords: 1, // Toggles scrambling of coordinates. 0 = No scrambling, 1 = scrambling. Default is 1.
+        serverScrambleMinimaps: 1, // Toggles scrambling of borders to render maps unusable. 0 = No scrambling, 1 = scrambling. Default is 1.
         serverTeamingAllowed: 1, // Toggles anti-teaming. 0 = Anti-team enabled, 1 = Anti-team disabled
         serverMaxLB: 10, //	Controls the maximum players displayed on the leaderboard.
         borderLeft: 0, // Left border of map (Vanilla value: 0)
@@ -728,9 +729,11 @@ GameServer.prototype.splitCells = function(client) {
         var deltaY = client.mouse.y - cell.position.y;
         var deltaX = client.mouse.x - cell.position.x;
         var angle = Math.atan2(deltaX, deltaY);
+        if (angle == 0) angle = Math.PI / 2;
+
         if (this.createPlayerCell(client, cell, angle, cell.mass / 2) == true) splitCells++;
     }
-    if (splitCells > 0) client.splittingMult += 0.3; // Account anti-teaming
+    if (splitCells > 0) client.splittingMult += 0.6; // Account anti-teaming
 };
 
 GameServer.prototype.createPlayerCell = function(client, parent, angle, mass) {
@@ -860,7 +863,7 @@ GameServer.prototype.getCellsInRange = function(cell) {
         }
 
         // Can't eat cells that have collision turned off
-        if ((cell.owner == check.owner) && (cell.collisionRestoreTicks != 0)) {
+        if ((cell.owner == check.owner) && (cell.collisionRestoreTicks != 0) && (check.cellType == 0)) {
             continue;
         }
 
@@ -997,7 +1000,7 @@ GameServer.prototype.updateCells = function() {
         if (cell.mass >= this.config.playerMinMassDecay) {
             var client = cell.owner;
             if (this.config.serverTeamingAllowed == 0) {
-                var teamMult = (client.massDecayMult - 1) / 570 + 1; // Calculate anti-teaming multiplier for decay
+                var teamMult = (client.massDecayMult - 1) / 666 + 1; // Calculate anti-teaming multiplier for decay
                 var thisDecay = 1 - massDecay * (1 / teamMult); // Reverse mass decay and apply anti-teaming multiplier
                 cell.mass *= (1 - thisDecay);
             } else {

--- a/src/PacketHandler.js
+++ b/src/PacketHandler.js
@@ -69,6 +69,8 @@ PacketHandler.prototype.handleMessage = function(message) {
                 client.mouse.x = view.getInt32(1, true) - client.scrambleX;
                 client.mouse.y = view.getInt32(5, true) - client.scrambleY;
             }
+
+            client.movePacketTriggered = true;
             break;
         case 17:
             // Space Press - Split cell

--- a/src/entity/PlayerCell.js
+++ b/src/entity/PlayerCell.js
@@ -51,7 +51,11 @@ PlayerCell.prototype.calcMergeTime = function(base) {
 // Movement
 
 PlayerCell.prototype.calcMove = function(x2, y2, gameServer, moveCell) {
+    this.collision(gameServer);
+
     if (moveCell) {
+        if (!this.owner.shouldMoveCells) return; // Mouse is in one place
+
         // Get angle of mouse
         var deltaY = y2 - this.position.y;
         var deltaX = x2 - this.position.x;
@@ -68,8 +72,6 @@ PlayerCell.prototype.calcMove = function(x2, y2, gameServer, moveCell) {
         this.position.x += Math.sin(angle) * speed;
         this.position.y += Math.cos(angle) * speed;
     }
-
-    this.collision(gameServer);
 };
 
 PlayerCell.prototype.collision = function(gameServer) {

--- a/src/entity/Virus.js
+++ b/src/entity/Virus.js
@@ -90,7 +90,7 @@ Virus.prototype.onConsume = function(consumer, gameServer) {
 
     // Prevent consumer cell from merging with other cells
     consumer.calcMergeTime(gameServer.config.playerRecombineTime);
-    client.virusMult += 0.6; // Account for anti-teaming
+    client.virusMult += 0.9; // Account for anti-teaming
 };
 
 Virus.prototype.onAdd = function(gameServer) {

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -9,6 +9,7 @@
 // serverStatsUpdate: Amount of seconds per update for server stats
 // serverLogLevel: Logging level of the server. 0 = No logs, 1 = Logs the console, 2 = Logs console and ip connections
 // serverScrambleCoords: Toggles scrambling of coordinates. 0 = No scrambling, 1 = scrambling. Default is 1.
+// serverScrambleMinimaps: Toggles scrambling of borders to render maps unusable. 0 = No scrambling, 1 = scrambling. Default is 1.
 // serverTeamingAllowed: Toggles anti-teaming. 0 = Anti-team enabled, 1 = Anti-team disabled. Default is 1.
 // serverMaxLB: Controls the maximum players displayed on the leaderboard.
 serverMaxConnections = 64
@@ -21,6 +22,7 @@ serverStatsPort = 88
 serverStatsUpdate = 60
 serverLogLevel = 1
 serverScrambleCoords = 1
+serverScrambleMinimaps = 1
 serverTeamingAllowed = 1
 serverMaxLB = 10
 


### PR DESCRIPTION
Resolves #508
- Tweaked anti-teaming
- Cells won't move if the mouse packet wasn't sent
- Free-roam spectating zoom increased to as having 6666 mass (or 6000, I forgot)
- If split angle is 0 then split right instead of down