### PR TITLE
Partially fix #536 + massive perfomance fix

### DIFF
--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -92,7 +92,6 @@ function GameServer() {
         playerMinMassDecay: 9, // Minimum mass for decay to occur
         playerMaxNickLength: 15, // Maximum nick length
         playerSpeed: 30, // Player base speed
-        playerSmoothSplit: 0, // Whether smooth splitting is used
         playerDisconnectTime: 60, // The amount of seconds it takes for a player cell to be removed after disconnection (If set to -1, cells are never removed)
         tourneyMaxPlayers: 12, // Maximum amount of participants for tournament style game modes
         tourneyPrepTime: 10, // Amount of ticks to wait after all players are ready (1 tick = 1000 ms)

--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -253,9 +253,11 @@ GameServer.prototype.getNewPlayerID = function() {
 };
 
 GameServer.prototype.getRandomPosition = function() {
+    var xSum = this.config.borderRight + this.config.borderLeft;
+    var ySum = this.config.borderBottom + this.config.borderTop;
     return {
-        x: Math.floor(Math.random() * (this.config.borderRight - this.config.borderLeft) + this.config.borderLeft),
-        y: Math.floor(Math.random() * (this.config.borderBottom - this.config.borderTop) + this.config.borderTop)
+        x: Math.floor(Math.random() * xSum - this.config.borderLeft),
+        y: Math.floor(Math.random() * ySum - this.config.borderTop)
     };
 };
 
@@ -411,10 +413,10 @@ GameServer.prototype.mainLoop = function() {
 
                     // Use sort function
                     clients.sort(function(a, b) {
-                        return a.getScore(true) - b.getScore(true);
+                        return b.playerTracker.getScore(true) - a.playerTracker.getScore(true);
                     });
-                    this.largestClient = clients[0];
-                } else this.largestClient = this.leaderboard[0];
+                    this.largestClient = clients[0].playerTracker;
+                } else this.largestClient = this.gameMode.rankOne;
 
                 this.tickMain = 0; // Reset
             }

--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -555,7 +555,7 @@ GameServer.prototype.checkCellCollision = function(cell, check) {
     return ({
         cellDist: dist,
         collideDist: collisionDist,
-        cellMult: (cell.getSpeed() / check.getSpeed()) / 2,
+        cellMult: (Math.sqrt(check.getSize() * 100) / Math.sqrt(cell.getSize() * 100)) / 3,
         cellAngle: angle,
         collided: (dist < collisionDist)
     });
@@ -701,7 +701,7 @@ GameServer.prototype.createPlayerCell = function(client, parent, angle, mass) {
 
     // Calculate customized speed for splitting cells
     var t = Math.PI * Math.PI;
-    var modifier = 3 + Math.log(1 + mass) / 10;
+    var modifier = 3 + Math.log(1 + mass) / (10 + Math.log(1 + mass));
     var splitSpeed = this.config.playerSpeed * Math.min(Math.pow(mass, -Math.PI / t / 10) * modifier, 150);
 
     // Calculate new position
@@ -713,7 +713,7 @@ GameServer.prototype.createPlayerCell = function(client, parent, angle, mass) {
     // Create cell
     var newCell = new Entity.PlayerCell(this.getNextNodeId(), client, newPos, mass, this);
     newCell.setAngle(angle);
-    newCell.setMoveEngineData(splitSpeed, 12, 0.87);
+    newCell.setMoveEngineData(splitSpeed, 12, 0.88);
     // Cells won't collide immediately
     newCell.collisionRestoreTicks = 12;
     parent.collisionRestoreTicks = 12;

--- a/src/GameServer.js
+++ b/src/GameServer.js
@@ -317,7 +317,7 @@ GameServer.prototype.addNode = function(node) {
 
         // client.nodeAdditionQueue is only used by human players, not bots
         // for bots it just gets collected forever, using ever-increasing amounts of memory
-        if ('_socket' in client.socket && node.visibleCheck(client.viewBox, client.centerPos)) {
+        if ('_socket' in client.socket && node.visibleCheck(client.viewBox, client.centerPos, client.cells)) {
             client.nodeAdditionQueue.push(node);
         }
     }
@@ -799,10 +799,10 @@ GameServer.prototype.getCellsInRange = function(cell) {
     var list = [];
     var squareR = cell.getSquareSize(); // Get cell squared radius
 
-    // Loop through all cells that are visible to the cell. There is probably a more efficient way of doing this but whatever
-    var len = cell.owner.visibleNodes.length;
+    // Loop through all cells that are colliding with the player's cells
+    var len = cell.owner.collidingNodes.length;
     for (var i = 0; i < len; i++) {
-        var check = cell.owner.visibleNodes[i];
+        var check = cell.owner.collidingNodes[i];
 
         if (typeof check === 'undefined') {
             continue;

--- a/src/PlayerTracker.js
+++ b/src/PlayerTracker.js
@@ -10,6 +10,7 @@ function PlayerTracker(gameServer, socket) {
     this.nodeAdditionQueue = [];
     this.nodeDestroyQueue = [];
     this.visibleNodes = [];
+    this.collidingNodes = []; // Perfomance save; all nodes colliding with player's cells
     this.cells = [];
     this.mergeOverride = false; // Triggered by console command
     this.score = 0; // Needed for leaderboard
@@ -113,6 +114,9 @@ PlayerTracker.prototype.getTeam = function() {
 PlayerTracker.prototype.update = function() {
     // Async update, perfomance reasons
     setTimeout(function() {
+        // First reset colliding nodes
+        this.collidingNodes = [];
+        
         // Move packet update
         if (this.movePacketTriggered) {
             this.movePacketTriggered = false;
@@ -432,9 +436,12 @@ PlayerTracker.prototype.calcVisibleNodes = function() {
             continue;
         }
 
-        if (node.visibleCheck(this.viewBox, this.centerPos) || node.owner == this) {
+        var check = node.visibleCheck(this.viewBox, this.centerPos, this.cells);
+        if (check > 0 || node.owner == this) {
             // Cell is in range of viewBox
             newVisible.push(node);
+            // Check if it's colliding with one of player's cells
+            if (check == 2) this.collidingNodes.push(node);
         }
     }
     return newVisible;

--- a/src/PlayerTracker.js
+++ b/src/PlayerTracker.js
@@ -373,8 +373,8 @@ PlayerTracker.prototype.getSpectateNodes = function() {
         if (!specPlayer) return this.moveInFreeRoam(); // There are probably no players
 
         // Get spectate player's location and calculate zoom amount
-        var specZoom = Math.min(Math.sqrt(100 * specPlayer.score), 444);
-        specZoom = Math.pow(Math.min(40.5 / specZoom, 1.0), 0.4) * 0.7;
+        var specZoom = Math.min(Math.sqrt(100 * specPlayer.score), 555);
+        specZoom = Math.pow(Math.min(40.5 / specZoom, 1.0), 0.4) * 0.6;
 
         this.setCenterPos(specPlayer.centerPos.x, specPlayer.centerPos.y);
         this.sendPosPacket(specZoom);
@@ -415,7 +415,7 @@ PlayerTracker.prototype.moveInFreeRoam = function() {
 
     // Use calcViewBox's way of looking for nodes
     var newVisible = this.calcVisibleNodes();
-    var specZoom = 444;
+    var specZoom = 222;
     specZoom = Math.pow(Math.min(40.5 / specZoom, 1.0), 0.4) * 0.6; // Constant zoom
     this.sendPosPacket(specZoom);
     return newVisible;

--- a/src/ai/BotPlayer.js
+++ b/src/ai/BotPlayer.js
@@ -84,8 +84,8 @@ BotPlayer.prototype.decide = function(cell) {
         var influence = 0;
         if (check.cellType == 0) {
             // Player cell
-            if (cell.owner.gameServer.gameMode.hasTeams && (cell.owner.team == check.owner.team)) influence = -1; // Same team cell
-            else if (cell.mass / 1.3 > check.mass) influence = check.getSize(); // Can eat it
+            if (this.gameServer.gameMode.haveTeams && (cell.owner.team == check.owner.team)) influence = 0; // Same team cell
+            else if (cell.mass / 1.3 > check.mass) influence = check.getSize() * 4; // Can eat it
             else if (check.mass / 1.3 > cell.mass) influence = -check.getSize(); // Can eat me
         } else if (check.cellType == 1) {
             // Food
@@ -123,8 +123,8 @@ BotPlayer.prototype.decide = function(cell) {
         var force = displacement.normalize().scale(influence);
 
         // Splitting conditions
-        if (check.cellType == 0 && cell.mass / 2.6 > check.mass &&
-            !split && this.splitCooldown == 0 && this.cells.length < 3) {
+        if (check.cellType == 0 && cell.mass / 2.6 > check.mass && cell.mass / 5 < check.mass &&
+            (!split) && this.splitCooldown == 0 && this.cells.length < 3) {
                 
             var endDist = this.splitDistance(cell);
             
@@ -144,15 +144,17 @@ BotPlayer.prototype.decide = function(cell) {
     // Check for splitkilling and threats
     if (split) {
         // Can be shortened but I'm too lazy
-        if (threats.length > 0) if (this.largest(threats).mass / 2.6 > cell.mass) { // ??? but works
-            // Splitkill the target
-            this.mouse = {
-                x: splitTarget.position.x,
-                y: splitTarget.position.y
-            };
-            this.splitCooldown = 16;
-            this.gameServer.splitCells(this);
-            return;
+        if (threats.length > 0) {
+            if (this.largest(threats).mass / 2.6 > cell.mass) { // ??? but works
+                // Splitkill the target
+                this.mouse = {
+                    x: splitTarget.position.x,
+                    y: splitTarget.position.y
+                };
+                this.splitCooldown = 16;
+                this.gameServer.splitCells(this);
+                return;
+            }
         }
         else {
             // Still splitkill the target
@@ -177,7 +179,7 @@ BotPlayer.prototype.largest = function(list) {
     // Sort the cells by Array.sort() function to avoid errors
     var sorted = list.valueOf();
     sorted.sort(function(a, b) {
-        return a.mass - b.mass;
+        return b.mass - a.mass;
     });
 
     return sorted[0];

--- a/src/ai/BotPlayer.js
+++ b/src/ai/BotPlayer.js
@@ -126,7 +126,7 @@ BotPlayer.prototype.decide = function(cell) {
         if (check.cellType == 0 && cell.mass / 2.6 > check.mass && cell.mass / 5 < check.mass &&
             (!split) && this.splitCooldown == 0 && this.cells.length < 3) {
                 
-            var endDist = this.splitDistance(cell);
+            var endDist = Math.max(this.splitDistance(cell), cell.getSize() * 4);
             
             if (distance < endDist - cell.getSize() - check.getSize()) {
                 splitTarget = check;

--- a/src/ai/BotPlayer.js
+++ b/src/ai/BotPlayer.js
@@ -85,14 +85,18 @@ BotPlayer.prototype.decide = function(cell) {
         if (check.cellType == 0) {
             // Player cell
             if (this.gameServer.gameMode.haveTeams && (cell.owner.team == check.owner.team)) influence = 0; // Same team cell
-            else if (cell.mass / 1.3 > check.mass) influence = check.getSize() * 4; // Can eat it
+            else if (cell.mass / 1.3 > check.mass) influence = check.getSize() * 2.5; // Can eat it
             else if (check.mass / 1.3 > cell.mass) influence = -check.getSize(); // Can eat me
         } else if (check.cellType == 1) {
             // Food
             influence = 1;
         } else if (check.cellType == 2) {
             // Virus
-            if (cell.mass / 1.3 > check.mass) influence = -0.8; // Can eat it
+            if (cell.mass / 1.3 > check.mass) {
+                // Can eat it
+                if (this.cells.length == this.gameServer.config.playerMaxCells) influence = check.getSize() * 2.5; // Won't explode
+                else influence = -1; // Can explode
+            }
         } else if (check.cellType == 3) {
             // Ejected mass
             if (cell.mass / 1.3 > check.mass) influence = check.getSize();

--- a/src/ai/BotPlayer.js
+++ b/src/ai/BotPlayer.js
@@ -47,6 +47,9 @@ BotPlayer.prototype.update = function() { // Overrides the update function from 
             return;
         }
     }
+    
+    if (this.splitCooldown > 0) this.splitCooldown--;
+    
     setTimeout(function() {
         // Calculate nodes
         this.visibleNodes = this.calcViewBox();
@@ -66,16 +69,40 @@ BotPlayer.prototype.update = function() { // Overrides the update function from 
 // Custom
 BotPlayer.prototype.decide = function(cell) {
     if (!cell) return; // Cell was eaten, check in the next tick (I'm too lazy)
+    
     var cellPos = cell.position;
     var result = new Vector(0, 0);
     // Splitting
-    var cellLength = this.cells.length,
-        splitCooldown = this.splitCooldown,
-        split = false,
+    var split = false,
         splitTarget = null,
         threats = [];
 
-    var algorithm = function(check, influence) {
+    for (var i = 0; i < this.visibleNodes.length; i++) {
+        var check = this.visibleNodes[i];
+        
+        // Get attraction of the cells - avoid larger cells, viruses and same team cells
+        var influence = 0;
+        if (check.cellType == 0) {
+            // Player cell
+            if (cell.owner.gameServer.gameMode.hasTeams && (cell.owner.team == check.owner.team)) influence = -1; // Same team cell
+            else if (cell.mass / 1.3 > check.mass) influence = check.getSize(); // Can eat it
+            else if (check.mass / 1.3 > cell.mass) influence = -check.getSize(); // Can eat me
+        } else if (check.cellType == 1) {
+            // Food
+            influence = 1;
+        } else if (check.cellType == 2) {
+            // Virus
+            if (cell.mass / 1.3 > check.mass) influence = -0.8; // Can eat it
+        } else if (check.cellType == 3) {
+            // Ejected mass
+            if (cell.mass / 1.3 > check.mass) influence = check.getSize();
+        } else {
+            influence = check.getSize(); // Might be TeamZ
+        }
+
+        // Apply influence if it isn't 0 or my cell
+        if (influence == 0 || cell.owner == check.owner) continue;
+        
         // Calculate separation between cell and check
         var checkPos = check.position;
         var displacement = new Vector(checkPos.x - cellPos.x, checkPos.y - cellPos.y);
@@ -96,18 +123,12 @@ BotPlayer.prototype.decide = function(cell) {
         var force = displacement.normalize().scale(influence);
 
         // Splitting conditions
-        if (check.cellType == 0 && cell.mass / 2.6 > check.mass && cell.mass / 5 < check.mass &&
-            !split && splitCooldown == 0 && cellLength < 3) {
-
-            // Calculate split distance and check if it is larger than the raw distance
-            var mass = cell.mass;
-            var t = Math.PI * Math.PI;
-            var modifier = 3 + Math.log(1 + mass) / 10;
-            var splitSpeed = cell.owner.gameServer.config.playerSpeed * Math.min(Math.pow(mass, -Math.PI / t / 10) * modifier, 150);
-            var endDist = Math.max(splitSpeed * 6.8, cell.getSize() * 2); // Checked via C#, final distance is near 6.512x splitSpeed
-
-            if (endDist > distance) {
-                // Set the target to split after every entity in visible nodes has passed
+        if (check.cellType == 0 && cell.mass / 2.6 > check.mass &&
+            !split && this.splitCooldown == 0 && this.cells.length < 3) {
+                
+            var endDist = this.splitDistance(cell);
+            
+            if (distance < endDist - cell.getSize() - check.getSize()) {
                 splitTarget = check;
                 split = true;
             }
@@ -117,38 +138,24 @@ BotPlayer.prototype.decide = function(cell) {
         }
     }
 
-    this.visibleNodes.forEach(function(check) {
-        // Get attraction of the cells - avoid larger cells, viruses and same team cells
-        var influence = 0;
-        if (check.cellType == 0) {
-            // Player cell
-            if (cell.owner.gameServer.gameMode.hasTeams && (cell.owner.team == check.owner.team)) influence = -1; // Same team cell
-            else if (cell.mass / 1.3 > check.mass) influence = check.getSize(); // Can eat it
-            else if (check.mass / 1.3 > cell.mass) influence = -check.getSize(); // Can eat me
-        } else if (check.cellType == 1) {
-            // Food
-            influence = 1;
-        } else if (check.cellType == 2) {
-            // Virus
-            if (cell.mass / 1.3 > check.mass) influence = -1; // Can eat it
-        } else if (check.cellType == 3) {
-            // Ejected mass
-            if (cell.mass / 1.3 > check.mass) influence = check.getSize();
-        } else {
-            influence = check.getSize(); // Might be TeamZ
-        }
-
-        // Apply influence if it isn't 0 or my cell
-        if (influence != 0 && cell.owner != check.owner) algorithm(check, influence);
-    });
-
     // Normalize the resulting vector
     result.normalize();
 
     // Check for splitkilling and threats
     if (split) {
-        if (threats.length > 0) if (this.largest(threats).mass / 2.6 > cell.mass) {
+        // Can be shortened but I'm too lazy
+        if (threats.length > 0) if (this.largest(threats).mass / 2.6 > cell.mass) { // ??? but works
             // Splitkill the target
+            this.mouse = {
+                x: splitTarget.position.x,
+                y: splitTarget.position.y
+            };
+            this.splitCooldown = 16;
+            this.gameServer.splitCells(this);
+            return;
+        }
+        else {
+            // Still splitkill the target
             this.mouse = {
                 x: splitTarget.position.x,
                 y: splitTarget.position.y
@@ -159,8 +166,8 @@ BotPlayer.prototype.decide = function(cell) {
         }
     }
     this.mouse = {
-        x: cellPos.x + result.x * 500,
-        y: cellPos.y + result.y * 500
+        x: cellPos.x + result.x * 800,
+        y: cellPos.y + result.y * 800
     };
 };
 
@@ -174,4 +181,15 @@ BotPlayer.prototype.largest = function(list) {
     });
 
     return sorted[0];
+};
+
+BotPlayer.prototype.splitDistance = function(cell) {
+    // Calculate split distance and check if it is larger than the raw distance
+    var mass = cell.mass;
+    var t = Math.PI * Math.PI;
+    var modifier = 3 + Math.log(1 + mass) / 10;
+    var splitSpeed = cell.owner.gameServer.config.playerSpeed * Math.min(Math.pow(mass, -Math.PI / t / 10) * modifier, 150);
+    var endDist = Math.max(splitSpeed * 12.8, cell.getSize() * 2); // Checked via C#, final distance is near 6.512x splitSpeed
+    
+    return endDist;
 };

--- a/src/entity/Cell.js
+++ b/src/entity/Cell.js
@@ -202,7 +202,7 @@ Cell.prototype.calcMovePhys = function(config) {
     }
 
     // Border check - Bouncy physics
-    var radius = this.getSize();
+    var radius = 40;
     if ((this.position.x - radius) < -config.borderLeft) {
         // Flip angle horizontally - Left side
         this.angle = 6.28 - this.angle;

--- a/src/entity/Cell.js
+++ b/src/entity/Cell.js
@@ -143,7 +143,16 @@ Cell.prototype.collisionCheck2 = function(objectSquareSize, objectPosition) {
 
 Cell.prototype.visibleCheck = function(box, centerPos, cells) {
     // Checks if this cell is visible to the player
-    if (this.collisionCheck(box.bottomY, box.topY, box.rightX, box.leftX)) {
+    var isThere = false;
+    if (this.mass < 100) isThere = this.collisionCheck(box.bottomY, box.topY, box.rightX, box.leftX);
+    else {
+        var cellSize = this.getSize();
+        var lenX = cellSize + box.width >> 0; // Width of cell + width of the box (Int)
+        var lenY = cellSize + box.height >> 0; // Height of cell + height of the box (Int)
+    
+        isThere = (this.abs(this.position.x - centerPos.x) < lenX) && (this.abs(this.position.y - centerPos.y) < lenY);
+    }
+    if (isThere) {
         // It is
         // To save perfomance, check if any client's cell collides with this cell
         for (var i = 0; i < cells.length; i++) {

--- a/src/entity/Cell.js
+++ b/src/entity/Cell.js
@@ -186,21 +186,21 @@ Cell.prototype.calcMovePhys = function(config) {
     }
 
     // Border check - Bouncy physics
-    var radius = 40;
-    if ((this.position.x - radius) < config.borderLeft) {
+    var radius = this.getSize();
+    if ((this.position.x - radius) < -config.borderLeft) {
         // Flip angle horizontally - Left side
         this.angle = 6.28 - this.angle;
-        X = config.borderLeft + radius;
+        X = -config.borderLeft + radius;
     }
     if ((this.position.x + radius) > config.borderRight) {
         // Flip angle horizontally - Right side
         this.angle = 6.28 - this.angle;
         X = config.borderRight - radius;
     }
-    if ((this.position.y - radius) < config.borderTop) {
+    if ((this.position.y - radius) < -config.borderTop) {
         // Flip angle vertically - Top side
         this.angle = (this.angle <= 3.14) ? 3.14 - this.angle : 9.42 - this.angle;
-        Y = config.borderTop + radius;
+        Y = -config.borderTop + radius;
     }
     if ((this.position.y + radius) > config.borderBottom) {
         // Flip angle vertically - Bottom side

--- a/src/entity/Cell.js
+++ b/src/entity/Cell.js
@@ -76,8 +76,8 @@ Cell.prototype.getSpeed = function() {
     // Old formulas:
     // return 5 + (20 * (1 - (this.mass/(70+this.mass))));
     // return this.gameServer.config.playerSpeed * Math.pow(this.mass, -0.22) * 50 / 40;
-    var tau = Math.PI * Math.PI;
-    return this.gameServer.config.playerSpeed * Math.pow(this.mass, -Math.PI / tau / 1.5);
+    var t = Math.PI * Math.PI;
+    return this.gameServer.config.playerSpeed * Math.pow(this.mass, -Math.PI / t / 1.5);
 };
 
 Cell.prototype.setAngle = function(radians) {
@@ -141,9 +141,25 @@ Cell.prototype.collisionCheck2 = function(objectSquareSize, objectPosition) {
     return (dx * dx + dy * dy + this.getSquareSize() <= objectSquareSize);
 };
 
-Cell.prototype.visibleCheck = function(box, centerPos) {
+Cell.prototype.visibleCheck = function(box, centerPos, cells) {
     // Checks if this cell is visible to the player
-    return this.collisionCheck(box.bottomY, box.topY, box.rightX, box.leftX);
+    if (this.collisionCheck(box.bottomY, box.topY, box.rightX, box.leftX)) {
+        // It is
+        // To save perfomance, check if any client's cell collides with this cell
+        for (var i = 0; i < cells.length; i++) {
+            var cell = cells[i];
+            if (!cell) continue;
+            
+            var dist = this.getDist(this.position.x, this.position.y, cell.position.x, cell.position.y);
+            var collideDist = cell.getSize() + this.getSize();
+            
+            if (dist < collideDist) {
+                return 2;
+            }// Colliding with one
+        }
+        return 1; // Not colliding with any
+    }
+    else return 0;
 };
 
 Cell.prototype.calcMovePhys = function(config) {

--- a/src/entity/PlayerCell.js
+++ b/src/entity/PlayerCell.js
@@ -92,7 +92,7 @@ PlayerCell.prototype.collision = function(gameServer) {
                 if (this.collisionRestoreTicks > 0 || cell.collisionRestoreTicks > 0) continue;
 
                 // Call gameserver's function to collide cells
-                var change = gameServer.cellCollision(this, cell, calcInfo);
+                gameServer.cellCollision(this, cell, calcInfo);
             }
         }
     }
@@ -100,19 +100,19 @@ PlayerCell.prototype.collision = function(gameServer) {
     gameServer.gameMode.onCellMove(this, gameServer);
 
     // Check to ensure we're not passing the world border (shouldn't get closer than a quarter of the cell's diameter)
-    if (this.position.x < config.borderLeft + r / 2) {
-        this.position.x = config.borderLeft + r / 2;
+    if (this.position.x < -config.borderLeft + r / 2) {
+        this.position.x = -config.borderLeft + r / 2;
     }
     if (this.position.x > config.borderRight - r / 2) {
         this.position.x = config.borderRight - r / 2;
     }
-    if (this.position.y < config.borderTop + r / 2) {
-        this.position.y = config.borderTop + r / 2;
+    if (this.position.y < -config.borderTop + r / 2) {
+        this.position.y = -config.borderTop + r / 2;
     }
     if (this.position.y > config.borderBottom - r / 2) {
         this.position.y = config.borderBottom - r / 2;
     }
-}
+};
 
 // Override
 

--- a/src/entity/PlayerCell.js
+++ b/src/entity/PlayerCell.js
@@ -13,20 +13,6 @@ PlayerCell.prototype = new Cell();
 
 // Main Functions
 
-PlayerCell.prototype.visibleCheck = function(box, centerPos) {
-    // Use old fashioned checking method if cell is small
-    if (this.mass < 100) {
-        return this.collisionCheck(box.bottomY, box.topY, box.rightX, box.leftX);
-    }
-
-    // Checks if this cell is visible to the player
-    var cellSize = this.getSize();
-    var lenX = cellSize + box.width >> 0; // Width of cell + width of the box (Int)
-    var lenY = cellSize + box.height >> 0; // Height of cell + height of the box (Int)
-
-    return (this.abs(this.position.x - centerPos.x) < lenX) && (this.abs(this.position.y - centerPos.y) < lenY);
-};
-
 PlayerCell.prototype.simpleCollide = function(check, d) {
     // Simple collision check
     var len = 2 * d >> 0; // Width of cell + width of the box (Int)

--- a/src/entity/Virus.js
+++ b/src/entity/Virus.js
@@ -90,7 +90,7 @@ Virus.prototype.onConsume = function(consumer, gameServer) {
 
     // Prevent consumer cell from merging with other cells
     consumer.calcMergeTime(gameServer.config.playerRecombineTime);
-    client.applyTeaming(0.9, 1); // Apply anti-teaming
+    client.applyTeaming(1.2, 1); // Apply anti-teaming
 };
 
 Virus.prototype.onAdd = function(gameServer) {

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -174,12 +174,9 @@ MotherCell.prototype.update = function(gameServer) {
     if (this.mass > 222) {
         // Always spawn food if the mother cell is larger than 222
         var cellSize = gameServer.config.foodMass;
-        if (this.mass > 222 + cellSize * 2) { // Spawn it twice if possible
-            this.spawnFood(gameServer);
-            this.spawnFood(gameServer);
-            this.mass -= cellSize;
-            this.mass -= cellSize;
-        } else if (this.mass > 222 + cellSize) {
+        var remaining = this.mass - 222;
+        var maxAmount = Math.min(Math.floor(remaining / cellSize), 2);
+        for (var i = 0; i < maxAmount; i++) {
             this.spawnFood(gameServer);
             this.mass -= cellSize;
         }
@@ -231,7 +228,7 @@ MotherCell.prototype.abs = function(n) {
 
 MotherCell.prototype.spawnFood = function(gameServer) {
     // Get starting position
-    var angle = Math.random() * 6.28; // (Math.PI * 2) ??? Precision is not our greatest concern here
+    var angle = Math.random() * 6.28;
     var r = this.getSize();
     var pos = {
         x: this.position.x + (r * Math.sin(angle)),

--- a/src/gamemodes/Experimental.js
+++ b/src/gamemodes/Experimental.js
@@ -262,12 +262,3 @@ MotherCell.prototype.onRemove = function(gameServer) {
         gameServer.gameMode.nodesMother.splice(index, 1);
     }
 };
-
-MotherCell.prototype.visibleCheck = function(box, centerPos) {
-    // Checks if this cell is visible to the player
-    var cellSize = this.getSize();
-    var lenX = cellSize + box.width >> 0; // Width of cell + width of the box (Int)
-    var lenY = cellSize + box.height >> 0; // Height of cell + height of the box (Int)
-
-    return (this.abs(this.position.x - centerPos.x) < lenX) && (this.abs(this.position.y - centerPos.y) < lenY);
-};

--- a/src/gamemodes/FFA.js
+++ b/src/gamemodes/FFA.js
@@ -84,6 +84,7 @@ FFA.prototype.updateLB = function(gameServer) {
         }
 
         var player = gameServer.clients[i].playerTracker;
+        if (player.disconnect > -1) continue; // Don't add disconnected players to list
         var playerScore = player.getScore(true);
         if (player.cells.length <= 0) {
             continue;

--- a/src/gamemodes/FFA.js
+++ b/src/gamemodes/FFA.js
@@ -43,10 +43,14 @@ FFA.prototype.onPlayerSpawn = function(gameServer, player) {
     // Check if there are ejected mass in the world.
     if (gameServer.nodesEjected.length > 0) {
         var index = Math.floor(Math.random() * 100) + 1;
-        if (index <= gameServer.config.ejectSpawnPlayer) {
+        if (index >= gameServer.config.ejectSpawnPlayer) {
             // Get ejected cell
-            var index = Math.floor(Math.random() * gameServer.nodesEjected.length);
+            index = Math.floor(Math.random() * gameServer.nodesEjected.length);
             var e = gameServer.nodesEjected[index];
+            if (e.moveEngineTicks > 0) {
+                // Ejected cell is currently moving
+                gameServer.spawnPlayer(player, pos, startMass);
+            }
 
             // Remove ejected mass
             gameServer.removeNode(e);
@@ -56,7 +60,7 @@ FFA.prototype.onPlayerSpawn = function(gameServer, player) {
                 x: e.position.x,
                 y: e.position.y
             };
-            startMass = e.mass;
+            startMass = Math.max(e.mass, gameServer.config.playerStartMass);
 
             var color = e.getColor();
             player.setColor({
@@ -101,4 +105,4 @@ FFA.prototype.updateLB = function(gameServer) {
     }
 
     this.rankOne = lb[0];
-};
+}

--- a/src/gameserver.ini
+++ b/src/gameserver.ini
@@ -68,7 +68,6 @@ ejectSpawnPlayer = 50
 // playerMassDecayRate: Amount of mass lost per tick (Multiplier) (1 tick = 1000 milliseconds)
 // playerMinMassDecay: Minimum mass for decay to occur
 // playerDisconnectTime: The amount of seconds it takes for a player cell to be removed after disconnection (If set to -1, cells are never removed)
-// playerSmoothSplit: Set to 1 for smooth splitting.
 playerStartMass = 10
 playerBotGrowEnabled = 1
 playerMaxMass = 22500
@@ -80,9 +79,8 @@ playerMassAbsorbed = 1.0
 playerMassDecayRate = .002
 playerMinMassDecay = 9
 playerMaxNickLength = 15
-playerSpeed = 30
+playerSpeed = 35
 playerDisconnectTime = 60
-playerSmoothSplit = 1
 
 // [Gamemode]
 // Custom gamemode settings


### PR DESCRIPTION
Partially fixes #536 . _I'm not dead._
- Zoom and node range at free roam adjusted to agar.io's
- Fixed small cells offsetting cells too much
- Some fixes here and there
- Fixed lazy splitting of bots
- Bots will now farm viruses
- A bit safer spawning for players [WIP; player cells are still spawning on viruses] which includes a warning message if it happens a lot
- Pellet eating doesn't use collisionCheck2 anymore; swapped by sqrt-based distance calculation which enables food to be eaten by any mass cell
- Shortened sorting algorithm in mainLoop
- Larger anti-teaming effect on virus explode
- Mass of new cell is max of ejected cell mass and config start mass
- Cells won't spawn on moving ejected cells
- Fixed wrong-behaving borderLeft and borderTop
- Made bouncy physics a lot more bouncier
- PlayerTracker update is now async
- Abolished config `playerSmoothSplit`
- **`getCellsInRange` in GameServer won't check for all cells in visible nodes, instead will check all cells that collide with any of client's cells**
### #536's suggestions
- [X] If a player spawns from an Ejected Mass, he will always have the size of that mass (13 by default), and not the size that is displayed on "PlayerStartMass" in "Gameserver.ini" (which is 43 in my case).
- [ ] 80% of the time you'll spawn very close to some other player/bot or even dead. (The same happens with viruses). **Partially fixed**
- [ ] In vanilla Agar.io, when you split with the cursor in the middle of the cell, it doesn't split horizontaly, it actually splits to alot of directions and then freezes.
- [ ] Cells still move when getting hit by a virus while mouse is in center. (used to work in previous versions of ogar but now it doesnt?)
- [X] Virus explosions could be a little better when big
- [ ] Splitpops do not work 90% of the time like they should
- [ ] Virus throws do not work
- [X] Doublesplits could be more accurate
- [X] Cells need to have a little more "bounce back" or "spring" to them when doublesplitting or tricksplitting. And just splitting in general.
- ~~When in max pieces, and max size in each of those pieces, cells cant surpass 360k mass. They should be able to #527~~ (It was actually fixed even before)
- [X] Cells on the same team on teams mode can prevent another cell from moving, this is very annoying cause sometimes bots like to stick to you
- [X] Smaller cells can push owners own bigger cells, and same with bots, which gives you a speed boost. This needs to be fixed
- [X] Bots are lazy and don't split for people most of the time
- ~~In vanilla agario, when doublesplitting, some of your cells have a chance of switching order, which allows you to splitkill someone when you doublesplit at them over a virus.~~ (Can't understand)
- [X] Splitting and w-ing against the border of the map should be more bouncy
- [X] The range of which a cell consumes another cell is too short (possible config for this?)
- [ ] Needs a better anti-bot system, servers can still get infested with suicide bots even when all anti-bot systems are active
- [X] Splitspeed and distance between cells when splitting needs to be increased. The seperation of the cells when splitting is slow af right now
- [X] Player speed needs to be 35 by default, as it is more similar to the regular speed of vanilla agario
- ~~When out of bot names in realisticnames.txt or botnames.txt, they should reuse the same names instead of bot[#], (bot then number of bot)~~ (Purely cosmetic things)

P.S. http://agar.io/?ip=ogar-luka967.c9users.io:8080 is my test server. I open it when I'm working on Ogar.
