### PR TITLE
Linux Install Script Fix + Virus Splitting Fix

### DIFF
--- a/ogar-linux-script.sh
+++ b/ogar-linux-script.sh
@@ -204,13 +204,13 @@ fi
 
 case "$1" in
 	install)
-		ogar_install
+		ogar_install $1 $2
 		;;
 	update)
-		ogar_update
+		ogar_update $1 $2
 		;;
 	uninstall)
-		ogar_uninstall
+		ogar_uninstall $1 $2
 		;;
 	"")
 		echo "Blank sub-command. Please specify if you want to install, update or uninstall."

--- a/src/entity/Virus.js
+++ b/src/entity/Virus.js
@@ -15,7 +15,7 @@ Virus.prototype = new Cell();
 Virus.prototype.calcMove = null; // Only for player controlled movement
 
 Virus.prototype.feed = function(feeder, gameServer) {
-    if (this.moveEngineTicks <= 1) this.setAngle(feeder.getAngle()); // Set direction if the virus explodes
+    if (this.moveEngineSpeed <= 1) this.setAngle(feeder.getAngle()); // Set direction if the virus explodes
     this.mass += feeder.mass;
     this.fed++; // Increase feed count
     feeder.setKiller(this);


### PR DESCRIPTION
The install, update, and uninstall needed the arguments passed to the
functions in order to make the installation work.
Virus would always pop downwards due to the move from moveEngineTicks to
moveEngineSpeed.