### PR TITLE
Prevent Ogar from crashing on restart if --expose-gc is not enabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function startServer() {
                                    gameServer.socketServer.close();
                                    gameServer.httpServer.close();
                                    gameServer = null;
-                                   global.gc(); // Force garbage collection
+                                   if (global.gc) global.gc(); // Force garbage collection
                                    process.stdout.write("\u001b[2J\u001b[0;0H"); // Clear the console
                                    startServer();
                                }, timeout);


### PR DESCRIPTION
@Luka967 forgot to check if `global.gc` exists. So if you run the server without --expose-gc enabled, it would crash