### PR TITLE
Use Buffer.alloc() to avoid deprecation

### DIFF
--- a/src/packet/DynamicBuffer.js
+++ b/src/packet/DynamicBuffer.js
@@ -1,4 +1,4 @@
-var tempBuf = new Buffer(8);
+var tempBuf = new Buffer.alloc(8);
 
 function DynamicBuffer(littleEndian) {
     this.littleEndian = littleEndian ? true : false;


### PR DESCRIPTION
Using Buffer() is deprecated because of security/usability issues. This fixes a line in packet/DynamicBuffer.js to use Buffer.alloc instead, as instructed by [this](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1) page in the NodeJS documentation.